### PR TITLE
Change cache key from request ip to Session ID

### DIFF
--- a/src/Http/Controllers/FastLoginController.php
+++ b/src/Http/Controllers/FastLoginController.php
@@ -102,6 +102,6 @@ class FastLoginController
 
     protected function getCacheKey()
     {
-        return 'fastlogin-request-'.sha1(request()->getHttpHost().request()->ip());
+        return 'fastlogin-request-'.sha1(request()->getHttpHost().session()->getId());
     }
 }


### PR DESCRIPTION
This PR changes the cache key, which stores the Credential Data needed to validate a login or registration assertion. The cache is used as changing the session data may regenerate the XSRF token needed for both requests, meaning the second request is invalid (the actual login request). 

Previously the cache key is a combo of the host and request IP, which would cause race conditions in places with multiple users on the same ip, cafes or offices etc, and likely prevent users from logging in.

Instead, the session id is used as a unique identifier. We can't use a user id has they haven't logged in yet. I do not think that using the session id will cause the session token to regenerate on Vapor, but maybe we need to test that. Nothing new is saved into the session.

I've tested this code with a mysql database session driver with Valet. Hopefully this can close #1 !