### PR TITLE
webauthn-lib 4.1 compatibility 

### DIFF
--- a/src/Http/Controllers/FastLoginController.php
+++ b/src/Http/Controllers/FastLoginController.php
@@ -50,7 +50,7 @@ class FastLoginController
             ],
         )->setAuthenticatorSelection(
             new Authenticator('platform')
-        );
+        )->setAttestation(CreationRequest::ATTESTATION_CONVEYANCE_PREFERENCE_NONE);
 
         $request->user()->webauthnCredentials->each(function($credential) use($creationRequest){
             $creationRequest->excludeCredential(


### PR DESCRIPTION
PublicKeyCredentialCreationOptions attestation is now required. 
https://www.w3.org/TR/webauthn-2/#sctn-none-attestation